### PR TITLE
Add unit tests for trading utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+pytest

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -1,0 +1,33 @@
+import importlib
+import sys
+import types
+
+import pandas as pd
+import pytest
+
+import indicators
+
+# Create a dummy 'core.indicators' module so that backtest can import it
+core_module = types.ModuleType("core")
+core_module.indicators = indicators
+sys.modules["core"] = core_module
+sys.modules["core.indicators"] = indicators
+
+import backtest
+
+
+def test_backtest_long_only(monkeypatch):
+    df = pd.DataFrame({"close": [10, 11, 12]})
+
+    def fake_sma(series, window):
+        return pd.Series([2, 2, 2], index=series.index)
+
+    def fake_rsi(series):
+        return pd.Series([20, 80, 50], index=series.index)
+
+    monkeypatch.setattr(backtest, "sma", fake_sma)
+    monkeypatch.setattr(backtest, "rsi", fake_rsi)
+
+    result = backtest.backtest_long_only(df, rsi_buy=30, rsi_sell=70)
+    assert result["equity"] == pytest.approx(1100)
+    assert result["return"] == pytest.approx(0.1)

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pandas as pd
+
+import indicators
+
+
+def test_sma_basic():
+    series = pd.Series([1, 2, 3, 4, 5], dtype=float)
+    result = indicators.sma(series, window=3)
+    expected = pd.Series([np.nan, np.nan, 2.0, 3.0, 4.0])
+    pd.testing.assert_series_equal(result, expected)

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,28 @@
+import pytest
+
+from signals import buy_signal, sell_signal
+
+
+@pytest.mark.parametrize(
+    "price,sma200,rsi,bb_low,expected",
+    [
+        (105, 100, 20, 110, True),
+        (95, 100, 20, 110, False),
+        (105, 100, 35, 110, False),
+        (105, 100, 20, 100, False),
+    ],
+)
+def test_buy_signal(price, sma200, rsi, bb_low, expected):
+    assert buy_signal(price, sma200, rsi, bb_low) == expected
+
+
+@pytest.mark.parametrize(
+    "price,rsi,bb_high,expected",
+    [
+        (110, 80, 120, True),  # RSI > 70
+        (110, 60, 100, True),  # Price >= Bollinger high
+        (110, 60, 120, False),
+    ],
+)
+def test_sell_signal(price, rsi, bb_high, expected):
+    assert sell_signal(price, rsi, bb_high) == expected


### PR DESCRIPTION
## Summary
- add pytest-based unit tests for indicators, trading signals, and backtesting
- include pandas and pytest as project dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement pandas)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68a6f215294c833094f6bd02ea6eec5c