### PR TITLE
chore: remove unused imports

### DIFF
--- a/data.py
+++ b/data.py
@@ -7,7 +7,6 @@ Responsable de la récupération des prix de cryptomonnaies depuis l’API CoinG
 import os
 import requests
 import pandas as pd
-from datetime import datetime
 
 COINGECKO_API = "https://api.coingecko.com/api/v3"
 

--- a/signals.py
+++ b/signals.py
@@ -4,8 +4,6 @@ Module signals.py
 Définit les règles simples pour générer des signaux d'achat/vente.
 """
 
-import pandas as pd
-
 def buy_signal(price: float, sma200: float, rsi_val: float, bb_low: float) -> bool:
     """
     Retourne True si les conditions d’achat sont réunies.

--- a/web.py
+++ b/web.py
@@ -17,8 +17,6 @@ ou :
 """
 
 from __future__ import annotations
-import os
-import time
 import requests
 import pandas as pd
 import streamlit as st


### PR DESCRIPTION
## Summary
- remove unused imports from data, web and signals modules

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8 data.py signals.py web.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f20d49cc833088168a52b389bf02