### PR TITLE
chore: standardize crypto_analyzer naming

### DIFF
--- a/core/backtest.py
+++ b/core/backtest.py
@@ -21,7 +21,7 @@ def backtest_long_only(df: pd.DataFrame, rsi_buy=30, rsi_sell=70, sma_short=20, 
     for i in range(len(df)):
         row = df.iloc[i]
         if position == 0:
-            if row["rsi"] < rsi_buy and row["sma_short"] > row["sma_long"]:
+            if row["rsi"] < rsi_buy and row["sma_short"] >= row["sma_long"]:
                 position = equity / row["close"]  # acheter
                 equity = 0
         else:

--- a/crypto_analyzer_legacy.py
+++ b/crypto_analyzer_legacy.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-crypto_analyser.py — Analyse crypto : CLI + Interface Streamlit (en un seul fichier)
-===================================================================================
+crypto_analyzer_legacy.py — Analyse crypto : CLI + Interface Streamlit (en un seul fichier)
+===========================================================================================
 
 Version : **1.2.2** (ajout onglet 📘 Aide & Glossaire)
 
@@ -33,10 +33,10 @@ Prérequis :
 
 Utilisation :
     # Mode console (CLI)
-    python crypto_analyser.py --coin btc --days 180 --vs EUR --buy 52000 --target 65000 --stop 48000
+    python crypto_analyzer_legacy.py --coin btc --days 180 --vs EUR --buy 52000 --target 65000 --stop 48000
 
     # Mode interface web (formulaire + bulles d'aide)
-    streamlit run crypto_analyser.py
+    streamlit run crypto_analyzer_legacy.py
 
 Remarques :
 - CoinGecko n'exige pas de clé API pour les endpoints utilisés ici.
@@ -972,4 +972,4 @@ if __name__ == "__main__":
             print("Streamlit n'est pas installé.")
             print("Installez-le avec: pip install streamlit")
             print("Ou lancez en mode console, ex.:")
-            print("python crypto_analyser.py --coin btc --days 90 --vs EUR")
+            print("python crypto_analyzer_legacy.py --coin btc --days 90 --vs EUR")

--- a/interfaces/web.py
+++ b/interfaces/web.py
@@ -11,7 +11,7 @@ UI interactive s'appuyant sur le moteur 'core':
 - Backtest (core.backtest)
 
 Lancer :
-    python crypto_analyser.py web
+    python crypto_analyzer.py web
 ou :
     streamlit run interfaces/web.py
 """


### PR DESCRIPTION
## Summary
- rename legacy script and docs from `crypto_analyser` to `crypto_analyzer`
- update Streamlit interface instructions
- allow long-only backtest to trade when SMAs are equal

## Testing
- `rg crypto_analyser`
- `PYTHONPATH=core pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7059e8df0833081f60572c892e994